### PR TITLE
Add compat bounds for old PackageCompiler and old julia

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -81,6 +81,7 @@ uuid = "522f3ed2-3f36-55e3-b6df-e94fee9b0c07"
 version = "0.5.0"
 
 [[LibGit2]]
+deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
 [[Libdl]]
@@ -106,6 +107,11 @@ uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
+[[NetworkOptions]]
+git-tree-sha1 = "ed3157f48a05543cce9b241e1f2815f7e843d96e"
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+version = "1.2.0"
+
 [[PackageCompiler]]
 deps = ["ArgParse", "Libdl", "Pkg", "REPL", "Serialization", "Test", "UUIDs", "WinRPM"]
 git-tree-sha1 = "3db96de5bc51934d50872b1122f3ebe258a5b4f2"
@@ -113,7 +119,7 @@ uuid = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
 version = "0.6.3"
 
 [[Pkg]]
-deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[Printf]]
@@ -121,7 +127,7 @@ deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [[REPL]]
-deps = ["InteractiveUtils", "Markdown", "Sockets"]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[Random]]
@@ -150,7 +156,7 @@ deps = ["LinearAlgebra", "SparseArrays"]
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [[Test]]
-deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[TextWrap]]

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,11 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [compat]
-julia = "1"
+ApplicationBuilderAppUtils = "0.1"
+ArgParse = "0.6"
+Glob = "1.2"
+PackageCompiler = "v0.6"
+julia = "1.0, 1.1, 1.2, 1.3"
 
 [extras]
 ApplicationBuilderAppUtils = "96374992-6a10-11e9-2fa0-73472aac04df"

--- a/test/build_app-cli.jl
+++ b/test/build_app-cli.jl
@@ -14,8 +14,10 @@ res2 = joinpath(@__DIR__, "runtests.jl") # lol sure this is a resource, why not.
 NEWARGS = Base.shell_split("""--verbose
         -R $res1 --resource $res2 -L $res1 --lib $res2
         $examples_hello "HelloWorld" $builddir""")
-eval(:(ARGS = $NEWARGS))
+OLDARGS = copy(ARGS)
+@eval (empty!(ARGS); append!(ARGS, $NEWARGS))
 @test 0 == include("$build_app_jl")
+@eval (empty!(ARGS); append!(ARGS, $OLDARGS))
 @test isdir("$builddir/HelloWorld.app")
 @test isfile("$builddir/HelloWorld.app/Contents/MacOS/hello")
 
@@ -23,6 +25,7 @@ eval(:(ARGS = $NEWARGS))
 @test isfile("$builddir/HelloWorld.app/Contents/Resources/$(basename(res1))")
 @test isfile("$builddir/HelloWorld.app/Contents/Resources/$(basename(res2))")
 @test isfile("$builddir/HelloWorld.app/Contents/Libraries/$(basename(res1))")
+
 end
 
 @testset "Exits without juliaprog_main" begin


### PR DESCRIPTION
This package was missing compat bounds, so stopped working with newer
releases of PackageCompiler. This commit adds Compat Bounds to this
old package so that at least it will continue to work if people are
interested in using it on older versions of julia.

Also fixup test for julia 1.3